### PR TITLE
HA 2025.1 removals: Replace deprecated constants with their newer replacements

### DIFF
--- a/custom_components/xcomfort_bridge/climate.py
+++ b/custom_components/xcomfort_bridge/climate.py
@@ -7,20 +7,18 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.climate.const import (
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE,
-    HVAC_MODE_AUTO,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_PRESET_MODE,
+    ClimateEntityFeature,
+    HVACAction,
     PRESET_ECO,
     PRESET_COMFORT,
+    HVACMode,
 )
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from .hub import XComfortHub
 from .const import DOMAIN, VERBOSE
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,8 +53,8 @@ async def async_setup_entry(
 
 
 class HASSXComfortRcTouch(ClimateEntity):
-    _attr_temperature_unit = TEMP_CELSIUS
-    _attr_hvac_modes = [HVAC_MODE_AUTO]
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.AUTO]
     _attr_supported_features = SUPPORT_FLAGS
 
     def __init__(self, hass: HomeAssistant, hub: XComfortHub, room: Room):
@@ -173,7 +171,7 @@ class HASSXComfortRcTouch(ClimateEntity):
 
     @property
     def hvac_mode(self):
-        return HVAC_MODE_AUTO
+        return HVACMode.AUTO
 
     @property
     def current_humidity(self):
@@ -183,9 +181,9 @@ class HASSXComfortRcTouch(ClimateEntity):
     @property
     def hvac_action(self):
         if self._state.power > 0:
-            return CURRENT_HVAC_HEAT
+            return HVACAction.HEATING
         else:
-            return CURRENT_HVAC_IDLE
+            return HVACAction.IDLE
 
     @property
     def max_temp(self):

--- a/custom_components/xcomfort_bridge/cover.py
+++ b/custom_components/xcomfort_bridge/cover.py
@@ -6,9 +6,9 @@ from xcomfort.devices import Shade
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    CoverEntityFeature,
-    DEVICE_CLASS_SHADE,
+    CoverDeviceClass,
     CoverEntity,
+    CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -67,7 +67,7 @@ class HASSXComfortShade(CoverEntity):
 
     @property
     def device_class(self):
-        return DEVICE_CLASS_SHADE
+        return CoverDeviceClass.SHADE
 
     async def async_added_to_hass(self):
         log(f"Added to hass {self._name} ")

--- a/custom_components/xcomfort_bridge/light.py
+++ b/custom_components/xcomfort_bridge/light.py
@@ -119,7 +119,7 @@ class HASSXComfortLight(LightEntity):
     @property
     def is_on(self):
         """Return true if light is on."""
-        return self._state.switch
+        return self._state and self._state.switch
 
     @property
     def color_mode(self) -> ColorMode:

--- a/custom_components/xcomfort_bridge/light.py
+++ b/custom_components/xcomfort_bridge/light.py
@@ -1,14 +1,11 @@
 import asyncio
+from functools import cached_property
 import logging
 from math import ceil
 
 from xcomfort.devices import Light
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
-    LightEntity,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity, ColorMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -66,6 +63,7 @@ class HASSXComfortLight(LightEntity):
         # self.versionFW = comp["versionFW"]
 
         self._unique_id = f"light_{DOMAIN}_{hub.identifier}-{device.device_id}"
+        self._color_mode = ColorMode.BRIGHTNESS if self._device.dimmable else ColorMode.ONOFF
 
     async def async_added_to_hass(self):
         log(f"Added to hass {self._name} ")
@@ -124,11 +122,12 @@ class HASSXComfortLight(LightEntity):
         return self._state.switch
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        if self._device.dimmable:
-            return SUPPORT_BRIGHTNESS
-        return 0
+    def color_mode(self) -> ColorMode:
+        return self._color_mode
+
+    @cached_property
+    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+        return {self._color_mode}
 
     async def async_turn_on(self, **kwargs):
         log(f"async_turn_on {self._name} : {kwargs}")

--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -18,11 +18,7 @@ from xcomfort.bridge import Room
 from xcomfort.devices import RcTouch
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
-    ENERGY_WATT_HOUR,
-    PERCENTAGE,
-)
+from homeassistant.const import PERCENTAGE, UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -68,7 +64,7 @@ class XComfortPowerSensor(SensorEntity):
         self._attr_device_class = SensorEntityDescription(
             key="current_consumption",
             device_class=SensorDeviceClass.ENERGY,
-            native_unit_of_measurement=ENERGY_WATT_HOUR,
+            native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             state_class=SensorStateClass.MEASUREMENT,
             name="Current consumption",
         )
@@ -92,7 +88,7 @@ class XComfortPowerSensor(SensorEntity):
 
     @property
     def native_unit_of_measurement(self):
-        return ENERGY_WATT_HOUR
+        return UnitOfEnergy.WATT_HOUR
 
     @property
     def native_value(self):
@@ -107,7 +103,7 @@ class XComfortEnergySensor(RestoreSensor):
         self._attr_device_class = SensorEntityDescription(
             key="energy_used",
             device_class=SensorDeviceClass.ENERGY,
-            native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL_INCREASING,
             name="Energy consumption",
         )
@@ -148,7 +144,7 @@ class XComfortEnergySensor(RestoreSensor):
 
     @property
     def native_unit_of_measurement(self):
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
     def native_value(self):

--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -75,7 +75,6 @@ class XComfortPowerSensor(SensorEntity):
         self._room.state.subscribe(lambda state: self._state_change(state))
 
     def _state_change(self, state):
-
         should_update = self._state is not None
 
         self._state = state
@@ -92,7 +91,7 @@ class XComfortPowerSensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._state.power
+        return self._state and self._state.power
 
 
 class XComfortEnergySensor(RestoreSensor):
@@ -123,7 +122,6 @@ class XComfortEnergySensor(RestoreSensor):
             self._consumption = cast(float, savedstate.native_value)
 
     def _state_change(self, state):
-
         should_update = self._state is not None
         self._state = state
         if should_update:
@@ -168,7 +166,6 @@ class XComfortHumiditySensor(SensorEntity):
         self._device.state.subscribe(lambda state: self._state_change(state))
 
     def _state_change(self, state):
-
         should_update = self._state is not None
 
         self._state = state
@@ -185,4 +182,4 @@ class XComfortHumiditySensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._state.humidity
+        return self._state and self._state.humidity


### PR DESCRIPTION
Without replacing these, HA logs that they'll be removed in 2025.1.

<img width="1496" alt="image" src="https://github.com/jankrib/ha-xcomfort-bridge/assets/43624/68624aa9-ca8b-4655-9963-34e2e22ae881">

I've only tested this on a recent commit of HA, and not an older version, but it seems like it's quite some time since the new constants were introduced:

> LightEntityFeature was introduced in April 2022

… according to https://github.com/home-assistant/core/pull/106622

Fixes #27 