### PR TITLE
Add door sensors and switches

### DIFF
--- a/custom_components/xcomfort_bridge/__init__.py
+++ b/custom_components/xcomfort_bridge/__init__.py
@@ -16,6 +16,7 @@ PLATFORMS = [
     Platform.COVER,
     Platform.LIGHT,
     Platform.SENSOR,
+    Platform.SWITCH
 ]
 
 

--- a/custom_components/xcomfort_bridge/__init__.py
+++ b/custom_components/xcomfort_bridge/__init__.py
@@ -10,7 +10,13 @@ from homeassistant.helpers.typing import ConfigType
 from .const import CONF_AUTH_KEY, CONF_IDENTIFIER, DOMAIN
 from .hub import XComfortHub
 
-PLATFORMS = [Platform.LIGHT, Platform.CLIMATE, Platform.SENSOR, Platform.COVER]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.COVER,
+    Platform.LIGHT,
+    Platform.SENSOR,
+]
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/xcomfort_bridge/binary_sensor.py
+++ b/custom_components/xcomfort_bridge/binary_sensor.py
@@ -1,0 +1,53 @@
+import logging
+
+from xcomfort.devices import DoorSensor, DoorWindowSensor, WindowSensor
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .hub import XComfortHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    hub = XComfortHub.get_hub(hass, entry)
+
+    devices = hub.devices
+
+    sensors = list()
+
+    for device in devices:
+        if isinstance(device, DoorWindowSensor):
+            sensors.append(XComfortDoorWindowSensor(device))
+
+    async_add_entities(sensors)
+
+
+class XComfortDoorWindowSensor(BinarySensorEntity):
+    def __init__(self, device: WindowSensor | DoorSensor) -> None:
+        """Initialize the unit binary sensor."""
+        super().__init__()
+        self._attr_name = device.name
+        self._attr_unique_id = f"xcomfort-{device.device_id}"
+        self._device = device
+        self._attr_state = device.is_open
+
+        if isinstance(device, WindowSensor):
+            self._attr_device_class = BinarySensorDeviceClass.WINDOW
+        elif isinstance(device, DoorSensor):
+            self._attr_device_class = BinarySensorDeviceClass.DOOR
+
+    async def async_added_to_hass(self):
+        if self._device.state is not None:
+            self._device.state.subscribe(lambda state: self._state_change(state))
+
+    def _state_change(self, state: bool):
+        self._attr_state = state
+        self.schedule_update_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._device and self._device.is_open

--- a/custom_components/xcomfort_bridge/climate.py
+++ b/custom_components/xcomfort_bridge/climate.py
@@ -7,20 +7,18 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.climate.const import (
-    CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE,
-    HVAC_MODE_AUTO,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_PRESET_MODE,
+    ClimateEntityFeature,
+    HVACAction,
     PRESET_ECO,
     PRESET_COMFORT,
+    HVACMode,
 )
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from .hub import XComfortHub
 from .const import DOMAIN, VERBOSE
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,8 +53,8 @@ async def async_setup_entry(
 
 
 class HASSXComfortRcTouch(ClimateEntity):
-    _attr_temperature_unit = TEMP_CELSIUS
-    _attr_hvac_modes = [HVAC_MODE_AUTO]
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.AUTO]
     _attr_supported_features = SUPPORT_FLAGS
 
     def __init__(self, hass: HomeAssistant, hub: XComfortHub, room: Room):
@@ -173,7 +171,7 @@ class HASSXComfortRcTouch(ClimateEntity):
 
     @property
     def hvac_mode(self):
-        return HVAC_MODE_AUTO
+        return HVACMode.AUTO
 
     @property
     def current_humidity(self):
@@ -183,9 +181,9 @@ class HASSXComfortRcTouch(ClimateEntity):
     @property
     def hvac_action(self):
         if self._state.power > 0:
-            return CURRENT_HVAC_HEAT
+            return HVACAction.HEATING
         else:
-            return CURRENT_HVAC_IDLE
+            return HVACAction.IDLE
 
     @property
     def max_temp(self):

--- a/custom_components/xcomfort_bridge/cover.py
+++ b/custom_components/xcomfort_bridge/cover.py
@@ -6,9 +6,9 @@ from xcomfort.devices import Shade
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    CoverEntityFeature,
-    DEVICE_CLASS_SHADE,
+    CoverDeviceClass,
     CoverEntity,
+    CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -67,7 +67,7 @@ class HASSXComfortShade(CoverEntity):
 
     @property
     def device_class(self):
-        return DEVICE_CLASS_SHADE
+        return CoverDeviceClass.SHADE
 
     async def async_added_to_hass(self):
         log(f"Added to hass {self._name} ")

--- a/custom_components/xcomfort_bridge/light.py
+++ b/custom_components/xcomfort_bridge/light.py
@@ -119,7 +119,7 @@ class HASSXComfortLight(LightEntity):
     @property
     def is_on(self):
         """Return true if light is on."""
-        return self._state.switch
+        return self._state and self._state.switch
 
     @property
     def color_mode(self) -> ColorMode:

--- a/custom_components/xcomfort_bridge/light.py
+++ b/custom_components/xcomfort_bridge/light.py
@@ -1,14 +1,11 @@
 import asyncio
+from functools import cached_property
 import logging
 from math import ceil
 
 from xcomfort.devices import Light
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
-    LightEntity,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity, ColorMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -66,6 +63,7 @@ class HASSXComfortLight(LightEntity):
         # self.versionFW = comp["versionFW"]
 
         self._unique_id = f"light_{DOMAIN}_{hub.identifier}-{device.device_id}"
+        self._color_mode = ColorMode.BRIGHTNESS if self._device.dimmable else ColorMode.ONOFF
 
     async def async_added_to_hass(self):
         log(f"Added to hass {self._name} ")
@@ -124,11 +122,12 @@ class HASSXComfortLight(LightEntity):
         return self._state.switch
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        if self._device.dimmable:
-            return SUPPORT_BRIGHTNESS
-        return 0
+    def color_mode(self) -> ColorMode:
+        return self._color_mode
+
+    @cached_property
+    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+        return {self._color_mode}
 
     async def async_turn_on(self, **kwargs):
         log(f"async_turn_on {self._name} : {kwargs}")

--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -18,11 +18,7 @@ from xcomfort.bridge import Room
 from xcomfort.devices import RcTouch
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
-    ENERGY_WATT_HOUR,
-    PERCENTAGE,
-)
+from homeassistant.const import PERCENTAGE, UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -68,7 +64,7 @@ class XComfortPowerSensor(SensorEntity):
         self._attr_device_class = SensorEntityDescription(
             key="current_consumption",
             device_class=SensorDeviceClass.ENERGY,
-            native_unit_of_measurement=ENERGY_WATT_HOUR,
+            native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             state_class=SensorStateClass.MEASUREMENT,
             name="Current consumption",
         )
@@ -92,7 +88,7 @@ class XComfortPowerSensor(SensorEntity):
 
     @property
     def native_unit_of_measurement(self):
-        return ENERGY_WATT_HOUR
+        return UnitOfEnergy.WATT_HOUR
 
     @property
     def native_value(self):
@@ -107,7 +103,7 @@ class XComfortEnergySensor(RestoreSensor):
         self._attr_device_class = SensorEntityDescription(
             key="energy_used",
             device_class=SensorDeviceClass.ENERGY,
-            native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             state_class=SensorStateClass.TOTAL_INCREASING,
             name="Energy consumption",
         )
@@ -148,7 +144,7 @@ class XComfortEnergySensor(RestoreSensor):
 
     @property
     def native_unit_of_measurement(self):
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
     def native_value(self):

--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -75,7 +75,6 @@ class XComfortPowerSensor(SensorEntity):
         self._room.state.subscribe(lambda state: self._state_change(state))
 
     def _state_change(self, state):
-
         should_update = self._state is not None
 
         self._state = state
@@ -92,7 +91,7 @@ class XComfortPowerSensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._state.power
+        return self._state and self._state.power
 
 
 class XComfortEnergySensor(RestoreSensor):
@@ -123,7 +122,6 @@ class XComfortEnergySensor(RestoreSensor):
             self._consumption = cast(float, savedstate.native_value)
 
     def _state_change(self, state):
-
         should_update = self._state is not None
         self._state = state
         if should_update:
@@ -168,7 +166,6 @@ class XComfortHumiditySensor(SensorEntity):
         self._device.state.subscribe(lambda state: self._state_change(state))
 
     def _state_change(self, state):
-
         should_update = self._state is not None
 
         self._state = state
@@ -185,4 +182,4 @@ class XComfortHumiditySensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._state.humidity
+        return self._state and self._state.humidity

--- a/custom_components/xcomfort_bridge/switch.py
+++ b/custom_components/xcomfort_bridge/switch.py
@@ -1,0 +1,81 @@
+import logging
+from typing import Optional
+
+from xcomfort.devices import Rocker
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, VERBOSE
+from .hub import XComfortHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def log(msg: str):
+    if VERBOSE:
+        _LOGGER.info(msg)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    hub = XComfortHub.get_hub(hass, entry)
+
+    switches = list()
+    for device in hub.devices:
+        if isinstance(device, Rocker):
+            _LOGGER.info(f"Adding {device}")
+            switch = XComfortSwitch(hass, device)
+            switches.append(switch)
+
+    async_add_entities(switches)
+
+
+class XComfortSwitch(SwitchEntity):
+    def __init__(self, hass: HomeAssistant, device: Rocker):
+        self.hass = hass
+
+        self._attr_device_class = SwitchDeviceClass.SWITCH
+        self._device = device
+        self._name = device.name
+        self._state = None
+        self.device_id = device.device_id
+
+        self._unique_id = f"switch_{DOMAIN}_{device.device_id}"
+
+    async def async_added_to_hass(self) -> None:
+        self._device.state.subscribe(self._state_change)
+
+    def _state_change(self, state) -> None:
+        self._state = state
+        should_update = self._state is not None
+
+        if should_update:
+            self.schedule_update_ha_state()
+            # Emit event to enable stateless automation, since
+            # actual switch state may be same as before
+            self.hass.bus.fire(self._unique_id, {"on": state})
+
+    @property
+    def is_on(self) -> Optional[bool]:
+        return self._state
+
+    @property
+    def name(self) -> str:
+        return self._device.name_with_controlled
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID."""
+        return self._unique_id
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    async def async_turn_on(self, **kwargs):
+        raise NotImplementedError()
+
+    async def async_turn_off(self, **kwargs):
+        raise NotImplementedError()


### PR DESCRIPTION
Depends on https://github.com/jankrib/xcomfort-python/pull/16

(Builds on https://github.com/jankrib/ha-xcomfort-bridge/pull/31, but couldn't make it the "base" of this PR since the PR is from a fork.)

I'm not sure how to best do the switch integration. It's probably best if they trigger events in addition to their state changes? My physical switches do not display any state as such, and I could imagine that "double clicking" could be turned into something useful with HA.

Haven't had time to properly learn about the event stuff in HA yet.